### PR TITLE
fix(pelicanconf_event.py): comenta la variable MASTODON_LINK para hac…

### DIFF
--- a/config/pelicanconf_event.py
+++ b/config/pelicanconf_event.py
@@ -33,7 +33,7 @@ LINKEND_LINK = "https://es.linkedin.com/company/python-espa%C3%B1a?trk=public_po
 TELEGRAM_LINK = None
 INSTAGRAM_LINK = "https://www.instagram.com/pycon_es/"
 BLUESKY_LINK = "https://web-cdn.bsky.app/profile/did:plc:irbbd7hhbmqhoklzmlfx2sju"
-MASTODON_LINK = "https://fosstodon.org/@pycones"
+# MASTODON_LINK = "https://fosstodon.org/@pycones"
 
 TICKETS_LINK = "https://pycones2025.eventbrite.es"
 CALL_FOR_PAPERS_LINK = "https://charlas.2025.es.pycon.org/pycones2022/cfp"


### PR DESCRIPTION
This pull request includes a small change to the `config/pelicanconf_event.py` file. The change comments out the `MASTODON_LINK` configuration.

Configuration update:

* [`config/pelicanconf_event.py`](diffhunk://#diff-431c256feb3eb50d003c7b4bca492829694810d2401668f108ca85ad5edea350L36-R36): Commented out the `MASTODON_LINK` configuration.…er desaparecer el icono