### PR TITLE
Pablo Olavides logo as a organizer

### DIFF
--- a/theme/templates/_includes/footer.html
+++ b/theme/templates/_includes/footer.html
@@ -9,6 +9,13 @@
                         </a>
                     </figure>
                 </div>
+                <div class="column">
+                    <figure class="image">
+                        <a href="https://www.upo.es/portal/impe/web/portada/index.html" target="_blank">
+                            <img alt="Universidad Pablo Olavides" src="{{SITEURL}}/theme/images/organizers/pablo_olavides.png">
+                        </a>
+                    </figure>
+                </div>
                 <div class="column is-vcentered is-centered" style="text-align: center">
                     <a href="{{ SITEURL }}/pages/code-of-conduct.html">
                         <button class="button is-medium is-orange button is-link is-dark">Código de conducta</button>


### PR DESCRIPTION
We need to add the logo of the University of Pablo Olavides as an organizer.

![imagen](https://github.com/user-attachments/assets/2d9029ac-0e08-4f6a-8f6a-cf85ea3d8ce1)
