### PR TITLE
Feat: adds c4p external link to navbar

### DIFF
--- a/config/pelicanconf_common.py
+++ b/config/pelicanconf_common.py
@@ -5,6 +5,7 @@ import pytz
 
 
 from pelicanconf_flags import *
+from pelicanconf_event import CALL_FOR_PAPERS_LINK
 
 AUTHOR = "Python España Org"
 SITENAME = "PyConES 2025 Sevilla"
@@ -50,6 +51,15 @@ MENUITEMS_NAVBAR = OrderedDict(
         "Código de Conducta": "/pages/code-of-conduct.html",
     }
 )
+
+if CALL_FOR_PAPERS_LINK:
+    MENUITEMS_NAVBAR["Llamada a ponentes"] = OrderedDict(
+        {
+            "url": CALL_FOR_PAPERS_LINK,
+            "target": "_blank",
+            "external": True,
+        }
+    )
 
 if ENABLED_TICKETS:
     MENUITEMS_NAVBAR["Tickets"] = "/tickets.html"

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -11,4 +11,8 @@ from config.pelicanconf_event import *
 from config.pelicanconf_flags import *
 
 SITEURL = os.getenv("SITEURL")
+
+if not SITEURL:
+    raise ValueError("SITEURL environment variable is not set")
+
 GOOGLE_ANALYTICS_CODE = os.getenv("GOOGLE_ANALYTICS_CODE", "0000")

--- a/theme/templates/_includes/navbar.html
+++ b/theme/templates/_includes/navbar.html
@@ -20,6 +20,10 @@
                         <a class="navbar-item" href="{{ SITEURL }}{{ link }}">
                             {{ item }}
                         </a>
+                            {% elif link is mapping and 'url' in link and 'external' in link and link.external %}
+                        <a class="navbar-item" href="{{ link.url }}" target="{{ link.target }}" rel="noopener noreferrer">
+                            {{ item }}
+                        </a>
                             {% elif link is mapping %}
                         <div class="navbar-item has-dropdown is-hoverable">
                             <a class="navbar-link">


### PR DESCRIPTION
This pull request introduces new functionality to support a "Call for Papers" link in the navigation menu, ensures proper configuration validation for the `SITEURL` environment variable, and updates the navbar template to handle external links. Below is a summary of the most important changes:

### New functionality for "Call for Papers" link:

* [`config/pelicanconf_common.py`](diffhunk://#diff-7225cf45fd15e5368e49044bd59dd262c03e78664dff3d42d1fd6e6357cfc0c9R8): Added a new import for `CALL_FOR_PAPERS_LINK` and updated the `MENUITEMS_NAVBAR` dictionary to include a "Llamada a ponentes" entry when the link is defined. This entry supports external URLs. [[1]](diffhunk://#diff-7225cf45fd15e5368e49044bd59dd262c03e78664dff3d42d1fd6e6357cfc0c9R8) [[2]](diffhunk://#diff-7225cf45fd15e5368e49044bd59dd262c03e78664dff3d42d1fd6e6357cfc0c9R55-R63)

### Configuration validation:

* [`pelicanconf.py`](diffhunk://#diff-d65cf0288f1d9a86915f40ad4e588bbbb59fd7b1f932ea9beaa39927e3bcf18cR14-R17): Added a check to ensure the `SITEURL` environment variable is set, raising a `ValueError` if it is not. This prevents misconfigurations during deployment.

### Navbar template enhancement:

* [`theme/templates/_includes/navbar.html`](diffhunk://#diff-4eaab528c9aff42defafe66a044e091c69660115c558d7909c9eca7b8b2a2865R22-R25): Updated the navbar template to handle external links by checking for specific attributes (`url`, `external`, and `target`) and rendering them with appropriate HTML attributes (`target="_blank"` and `rel="noopener noreferrer"`).