### PR TITLE
fix: Separate .message-header from is-info styles to avoid font color disappearing in the background

### DIFF
--- a/theme/static/scss/style.scss
+++ b/theme/static/scss/style.scss
@@ -116,7 +116,7 @@ p {
   background-color: rgba(0,0,0,0.6);
 }
 
-.message.is-info .message-header {
+.message.is-info {
   color: $pycon-dark-blue;
 }
 


### PR DESCRIPTION
This PR tries to fix non-legible fonts for the info pages, see the example: 
![image](https://github.com/user-attachments/assets/8bea534a-c5c7-4228-af49-1b751fb2fa23)

To:
![image](https://github.com/user-attachments/assets/2629c7df-9198-4d7c-9ba5-e214f1a56943)

**Considerations**:  Setting a color for .message-header class couldn't be done without passing !important, so the inherit font color for this class is white #fff .(Where another style with higher specificity or a !important declaration is overriding this color setting) So I am open to your comments about which would be the most appropriate color to use based on the defined color palette or if we should keep that color, which is the one being inherited.